### PR TITLE
chore: Fix semantic-release authorization

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -26,7 +28,7 @@ jobs:
       - name: Semantic Release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_SR_TOKEN }}
 
   build-and-push-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Attempt to fix the CI issue with semantic-release which has to get the permissions to write in the repo and bypass the main branch protections.
Following this [doc](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md), we set `persist-credentials` to false and created a token for an bot user.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)