### PR TITLE
feat: Allow semantic-release to trigger itself the docker push and release

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,44 +1,17 @@
 name: Docker build and push
 
 on:
-  workflow_run:
-    workflows: [ "Tests" ]
-    types: [ completed ]
-    branches: [ main, next ]
-
+  push:
+    tags:
+      - 'v*'
 env:
   REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
   IMAGE_NAME: "annotto-front"
 
 jobs:
-  debug-tests-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo 'The triggering workflow failed'
-
-  semantic-release:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      - name: Install dependencies
-        run: yarn install
-      - name: Semantic Release
-        run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_SR_TOKEN }}
-
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: ["semantic-release"]
+    needs: [ "semantic-release" ]
     permissions:
       contents: read
       packages: write
@@ -60,36 +33,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Extract branch name
-        id: extract_branch
-        shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=base_url;]$(echo BASE_URL_${GITHUB_REF#refs/heads/} | tr [:lower:] [:upper:] )"
-          echo "##[set-output name=keycloak_url;]$(echo KEYCLOAK_URL_${GITHUB_REF#refs/heads/} | tr [:lower:] [:upper:] )"
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Inspect builder
-        run: |
-          echo "Name:      ${{ steps.buildx.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        env:
-          BASE_URL: ${{ secrets[steps.extract_branch.outputs.base_url] }}
-          KEYCLOAK_URL: ${{ secrets[steps.extract_branch.outputs.keycloak_url] }}
         with:
           context: .
           push: true
-          build-args: |
-            BASE_URL=${{ env.BASE_URL }}
-            KEYCLOAK_URL=${{ env.KEYCLOAK_URL }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Docker build and push
+
+on:
+  workflow_run:
+    workflows: [ "Tests" ]
+    types: [ completed ]
+    branches: [ main, next ]
+
+jobs:
+  debug-tests-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'
+
+  semantic-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Semantic Release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SR_TOKEN }}


### PR DESCRIPTION
New workflows behavious

Workflows are 
1. Tests
2. release
3. docker build and push

Release workflow is always triggering after tests are done. If a release is made possible by semantic release, then a new tag will be pushed, and this will trigger the docker build and push workflow.

Closes #15

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?


### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
